### PR TITLE
Change the default value of resolved_elapse to 0.0

### DIFF
--- a/igsn_lib/models/thing.py
+++ b/igsn_lib/models/thing.py
@@ -77,7 +77,7 @@ class Thing(igsn_lib.models.Base):
     )
     resolve_elapsed = sqlalchemy.Column(
         sqlalchemy.Float,
-        default=None,
+        default=0.0,
         nullable=True,
         doc="Time in seconds to resolve record",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "igsn_lib"
-version = "0.5.3"
+version = "0.5.4"
 description = "Utilities for working with IGSNs"
 authors = ["datadavev <datadavev@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Attempt to fix the issue from fastapi being unhappy with None in `resolve_elapsed`.